### PR TITLE
精确检测localstorage是否可用

### DIFF
--- a/1.1/build/basic.js
+++ b/1.1/build/basic.js
@@ -49,7 +49,8 @@ KISSY.add('gallery/storage/1.1/basic', function(S, JSON) {
         }
         store.getAll = function() {
         }
-
+        store.key = function(index) {
+        }
         store.serialize = function(value) {
             return JSON.stringify(value)
         }
@@ -102,6 +103,9 @@ KISSY.add('gallery/storage/1.1/basic', function(S, JSON) {
                     ret[key] = store.get(key)
                 }
                 return ret
+            }
+            store.key = function(index) {
+                return storage.key(index);
             }
         }
         else if (doc.documentElement.addBehavior) {
@@ -195,16 +199,31 @@ KISSY.add('gallery/storage/1.1/basic', function(S, JSON) {
                 }
                 return ret
             })
+            store.key = withIEStorage(function(storage, index) {
+                var keys = []
+                store.forEach(function(key, val) {
+                    keys.push(key)
+                })
+                return keys[index]
+            })
         }
 
         //alert(namespace + '-' + store.get(namespace));
         try {
-            store.set(namespace, namespace)
-            //alert(namespace + '-' + store.get(namespace));
-            if (store.get(namespace) != namespace) {
-                store.disabled = true
+            //精确检测，防止我们自己cache大于storage的上限以后,检测不准
+            var tempKey = store.key(0)
+            var tempData = store.get(tempKey)
+            if(tempKey) {
+                store.remove(tempKey)
+                store.set(tempKey, tempData)
+            } else {
+                store.set(namespace, namespace)
+                //alert(namespace + '-' + store.get(namespace));
+                if (store.get(namespace) != namespace) {
+                    store.disabled = true
+                }
+                store.remove(namespace)
             }
-            store.remove(namespace)
         } catch (e) {
             store.disabled = true
         }
@@ -224,4 +243,3 @@ KISSY.add('gallery/storage/1.1/basic', function(S, JSON) {
 }, {
     requires: ['json']
 });
-


### PR DESCRIPTION
这里会遇到一种情况，当cache的存储到达上限以后，页面重新进来再次检测都是不支持localstorage(但这时除了set以外的接口全部可以使
用)，不过我对ie的userData不是很熟悉，fixed一个方法，望更正
